### PR TITLE
fix: update ESLint config for flat config compatibility

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -5,6 +5,9 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import reactPlugin from "eslint-plugin-react";
 
 export default [
+  {
+    files: ["**/*.ts", "**/*.tsx"]
+  },
   // Ignore dirs
   { ignores: ["dist/", ".vite/"] },
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
# Fix ESLint Configuration for Flat Config System

## Problem
When using ESLint's new flat configuration system, the `--ext` command line flag is no longer supported. This was causing the following error when running the lint command:

```
Invalid option '--ext' - perhaps you meant '-c'?
You're using eslint.config.js, some command line flags are no longer available.
```

## Solution
This PR updates the ESLint configuration to work with the flat config system by:
1. Removing the `--ext ts,tsx` flag from the lint script in `package.json`
2. Adding explicit file patterns in `eslint.config.mjs` to handle TypeScript and TSX files

## Changes
- `package.json`: Removed `--ext ts,tsx` from the lint script
- `eslint.config.mjs`: Added file patterns configuration:
  ```javascript
  {
    files: ["**/*.ts", "**/*.tsx"]
  }
  ```

## Testing
- Verified that `npm run lint` executes successfully
- Confirmed that TypeScript and TSX files are being linted properly
- No changes to existing lint rules or behavior

## References
- [ESLint Command Line Interface Documentation](https://eslint.org/docs/latest/use/command-line-interface)
- [ESLint Flat Config Migration Guide](https://eslint.org/docs/latest/use/configure/configuration-files-new)

Closes #441 